### PR TITLE
Improvement/PlanetButton, PlanetScaffold, BaseTextField, PlanetToolbar

### DIFF
--- a/customer-component/src/main/java/com/planetoto/customer_component/ui/BaseTextField.kt
+++ b/customer-component/src/main/java/com/planetoto/customer_component/ui/BaseTextField.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.planetoto.customer_component.R
+import com.planetoto.customer_component.foundation.LocalPadding
 import com.planetoto.customer_component.foundation.PlanetColors
 import com.planetoto.customer_component.foundation.PlanetTypography
 
@@ -133,7 +134,8 @@ internal fun BaseTextField(
                     AnimatedVisibility(
                         visible = text.isNotEmpty() && hasClearAction,
                         enter = scaleIn(),
-                        exit = scaleOut()
+                        exit = scaleOut(),
+                        modifier = Modifier.padding(end = LocalPadding.current.xSmall)
                     ) {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_close_rounded),

--- a/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetButton.kt
+++ b/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetButton.kt
@@ -13,18 +13,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.planetoto.customer_component.foundation.LocalBorderRadius
 import com.planetoto.customer_component.foundation.PlanetColors
 import com.planetoto.customer_component.foundation.PlanetTypography
 import com.planetoto.customer_component.utils.capitalizeWords
 
-enum class PlanetButtonSize {
-    Medium, Large
+sealed class PlanetButtonSize(val height: Dp, val typography: PlanetTypography) {
+    object Medium : PlanetButtonSize(36.dp, PlanetTypography.LabelMediumButton)
+    object Large : PlanetButtonSize(50.dp, PlanetTypography.LabelBigButton)
 }
 
-enum class PlanetButtonType {
-    Primary, Secondary
+sealed interface PlanetButtonType {
+    object Primary : PlanetButtonType
+    object Secondary : PlanetButtonType
+    data class Tertiary(
+        val contentColor: PlanetColors.Solid,
+        val backgroundColor: PlanetColors.Solid
+    ) : PlanetButtonType
 }
 
 @Composable
@@ -32,7 +39,7 @@ fun PlanetButton(
     modifier: Modifier = Modifier,
     text: String,
     enabled: Boolean = true,
-    size: PlanetButtonSize = PlanetButtonSize.Medium,
+    size: PlanetButtonSize = PlanetButtonSize.Large,
     type: PlanetButtonType = PlanetButtonType.Primary,
     iconPainter: Painter? = null,
     contentPadding: PaddingValues = PaddingValues(vertical = 10.dp, horizontal = 15.dp),
@@ -44,18 +51,6 @@ fun PlanetButton(
             if (hasFocus && enabled) BorderStroke(1.dp, PlanetColors.Solid.red07.color) else null
         }
     }
-    val height = remember(size) {
-        when (size) {
-            PlanetButtonSize.Medium -> 36.dp
-            PlanetButtonSize.Large -> 50.dp
-        }
-    }
-    val typography = remember(size) {
-        when (size) {
-            PlanetButtonSize.Medium -> PlanetTypography.LabelMediumButton
-            PlanetButtonSize.Large -> PlanetTypography.LabelBigButton
-        }
-    }
 
     when (type) {
         PlanetButtonType.Primary -> {
@@ -65,7 +60,7 @@ fun PlanetButton(
 
             Button(
                 modifier = modifier
-                    .height(height)
+                    .height(size.height)
                     .onFocusChanged {
                         hasFocus = it.hasFocus || it.isFocused
                     },
@@ -89,7 +84,7 @@ fun PlanetButton(
             ) {
                 PlanetText(
                     text = text.capitalizeWords(),
-                    typography = typography,
+                    typography = size.typography,
                     color = textColor
                 )
                 iconPainter?.let {
@@ -108,7 +103,7 @@ fun PlanetButton(
 
             Button(
                 modifier = modifier
-                    .height(height)
+                    .height(size.height)
                     .onFocusChanged {
                         hasFocus = it.hasFocus || it.isFocused
                     },
@@ -132,7 +127,7 @@ fun PlanetButton(
             ) {
                 PlanetText(
                     text = text.capitalizeWords(),
-                    typography = typography,
+                    typography = size.typography,
                     color = textColor
                 )
                 iconPainter?.let {
@@ -144,11 +139,24 @@ fun PlanetButton(
                 }
             }
         }
+        is PlanetButtonType.Tertiary -> {
+            PlanetOutlinedButton(
+                modifier = modifier,
+                text = text,
+                enabled = enabled,
+                size = size,
+                iconPainter = iconPainter,
+                contentPadding = contentPadding,
+                color = type.contentColor,
+                backgroundColor = type.backgroundColor,
+                onClick = onClick
+            )
+        }
     }
 }
 
 @Composable
-fun PlanetOutlinedButton(
+private fun PlanetOutlinedButton(
     modifier: Modifier = Modifier,
     text: String,
     enabled: Boolean = true,
@@ -165,22 +173,10 @@ fun PlanetOutlinedButton(
             if (hasFocus && enabled) PlanetColors.Solid.red07 else null
         }
     }
-    val height = remember(size) {
-        when (size) {
-            PlanetButtonSize.Medium -> 36.dp
-            PlanetButtonSize.Large -> 50.dp
-        }
-    }
-    val typography = remember(size) {
-        when (size) {
-            PlanetButtonSize.Medium -> PlanetTypography.LabelMediumButton
-            PlanetButtonSize.Large -> PlanetTypography.LabelBigButton
-        }
-    }
 
     OutlinedButton(
         modifier = modifier
-            .height(height)
+            .height(size.height)
             .onFocusChanged {
                 hasFocus = it.hasFocus || it.isFocused
             },
@@ -203,7 +199,7 @@ fun PlanetOutlinedButton(
     ) {
         PlanetText(
             text = text.capitalizeWords(),
-            typography = typography,
+            typography = size.typography,
             color = color
         )
         iconPainter?.let {

--- a/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetScaffold.kt
+++ b/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetScaffold.kt
@@ -104,7 +104,7 @@ fun PlanetScaffold(
     drawerBackgroundColor: Color = MaterialTheme.colors.surface,
     drawerContentColor: Color = contentColorFor(drawerBackgroundColor),
     drawerScrimColor: Color = DrawerDefaults.scrimColor,
-    backgroundColor: Color = Color.Transparent,
+    backgroundColor: Color = Color.White,
     backgroundImage: (@Composable () -> Unit)? = null,
     contentColor: Color = contentColorFor(backgroundColor),
     content: @Composable (PaddingValues) -> Unit
@@ -180,7 +180,7 @@ fun PlanetScaffold(
     sideDialogContent: @Composable ColumnScope.() -> Unit,
     sideDialogWidth: Dp? = null,
     sideDialogBackgroundColor: Color = MaterialTheme.colors.surface,
-    backgroundColor: Color = Color.Transparent,
+    backgroundColor: Color = Color.White,
     backgroundImage: (@Composable () -> Unit)? = null,
     contentColor: Color = contentColorFor(backgroundColor),
     content: @Composable (PaddingValues) -> Unit
@@ -249,7 +249,7 @@ fun PlanetScaffold(
     sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
     isSheetDraggable: Boolean = true,
     tapOutsideSheetToDismiss: Boolean = true,
-    backgroundColor: Color = Color.Transparent,
+    backgroundColor: Color = Color.White,
     backgroundImage: (@Composable () -> Unit)? = null,
     contentColor: Color = contentColorFor(backgroundColor),
     content: @Composable (PaddingValues) -> Unit
@@ -324,7 +324,7 @@ fun PlanetScaffold(
     sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
     isSheetDraggable: Boolean = true,
     tapOutsideSheetToDismiss: Boolean = true,
-    backgroundColor: Color = Color.Transparent,
+    backgroundColor: Color = Color.White,
     contentColor: Color = contentColorFor(backgroundColor),
     backgroundImage: (@Composable () -> Unit)? = null,
     content: @Composable (PaddingValues) -> Unit

--- a/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetSearchInput.kt
+++ b/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetSearchInput.kt
@@ -34,7 +34,7 @@ fun PlanetSearchInput(
     enabled: Boolean = true,
     hasClearAction: Boolean = true,
     onTextChange: (String) -> Unit,
-    onSearchClicked: (String) -> Unit
+    onSearchClicked: ((String) -> Unit)? = null
 ) {
     BaseTextField(
         modifier = modifier,
@@ -45,7 +45,7 @@ fun PlanetSearchInput(
         enabled = enabled,
         readOnly = false,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-        keyboardActions = KeyboardActions(onSearch = { onSearchClicked(text) }),
+        keyboardActions = KeyboardActions(onSearch = { onSearchClicked?.invoke(text) }),
         singleLine = true,
         size = size,
         helperText = helperText,
@@ -55,7 +55,7 @@ fun PlanetSearchInput(
             Box(
                 modifier = Modifier
                     .size(it)
-                    .clickable { onSearchClicked(text) },
+                    .clickable { onSearchClicked?.invoke(text) },
                 contentAlignment = Alignment.Center
             ) {
                 Icon(

--- a/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetToolbar.kt
+++ b/customer-component/src/main/java/com/planetoto/customer_component/ui/PlanetToolbar.kt
@@ -33,7 +33,8 @@ fun PlanetToolbar(
             PlanetText(
                 text = title,
                 color = PlanetColors.Solid.neutralWhite,
-                typography = PlanetTypography.TitleBody
+                typography = PlanetTypography.TitleBody,
+                maxLines = 1
             )
         },
         backgroundColor = backgroundColor,
@@ -71,7 +72,7 @@ fun PlanetToolbar(
             IconButton(
                 onClick = onNavigateUp,
                 content = navigateUpIcon,
-                modifier = Modifier.padding(end = 16.dp)
+                modifier = Modifier.padding(end = 10.dp)
             )
         }
 


### PR DESCRIPTION
## IMPROVEMENT
1. Simplify call to PlanetOutlinedButton via PlanetButton
2. Make title on PlanetToolbar to single line
3. Set white as default background in PlanetScaffold
4. Add padding after "clear" action in BaseTextField
5. Set PlanetButton default size to Large
6. Set onSearchClicked null by default in PlanetSearchInput